### PR TITLE
Change the way datatabletype works a bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@ All notable changes to `omines\datatables-bundle` will be documented in this fil
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-Nothing yet.
+
+### Breaking
+ - Added DataTableType Abstract class, you can extend this instead of implementing DataTableTypeInterface to maintain BC with anything existing
+ - Changed DataTableTypeInterface to support resolver options for both the type itself, and for the datatable to encapsulate settings in a type
 
 ## [0.8.0] - 2023-12-05
 ### Breaking

--- a/src/DataTableType.php
+++ b/src/DataTableType.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * Symfony DataTables Bundle
+ * (c) Omines Internetbureau B.V. - https://omines.nl/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Omines\DataTablesBundle;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+abstract class DataTableType implements DataTableTypeInterface
+{
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+    }
+
+    public function configureTableOptions(OptionsResolver $resolver): void
+    {
+    }
+}

--- a/src/DataTableTypeInterface.php
+++ b/src/DataTableTypeInterface.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Omines\DataTablesBundle;
 
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
 /**
  * DataTableTypeInterface.
  *
@@ -23,4 +25,14 @@ interface DataTableTypeInterface
      * @param array<string, mixed> $options
      */
     public function configure(DataTable $dataTable, array $options): void;
+
+    /**
+     * Configures the options for this type.
+     */
+    public function configureOptions(OptionsResolver $resolver): void;
+
+    /**
+     * Configures the options for this table.
+     */
+    public function configureTableOptions(OptionsResolver $resolver): void;
 }

--- a/tests/Fixtures/AppBundle/DataTable/Type/CustomQueryTableType.php
+++ b/tests/Fixtures/AppBundle/DataTable/Type/CustomQueryTableType.php
@@ -18,7 +18,7 @@ use Doctrine\ORM\QueryBuilder;
 use Omines\DataTablesBundle\Adapter\Doctrine\ORMAdapter;
 use Omines\DataTablesBundle\Column\TextColumn;
 use Omines\DataTablesBundle\DataTable;
-use Omines\DataTablesBundle\DataTableTypeInterface;
+use Omines\DataTablesBundle\DataTableType;
 use Tests\Fixtures\AppBundle\Entity\Employee;
 use Tests\Fixtures\AppBundle\Entity\Person;
 
@@ -27,7 +27,7 @@ use Tests\Fixtures\AppBundle\Entity\Person;
  *
  * @author Niels Keurentjes <niels.keurentjes@omines.com>
  */
-class CustomQueryTableType implements DataTableTypeInterface
+class CustomQueryTableType extends DataTableType
 {
     public function configure(DataTable $dataTable, array $options): void
     {

--- a/tests/Fixtures/AppBundle/DataTable/Type/Grouped2TableType.php
+++ b/tests/Fixtures/AppBundle/DataTable/Type/Grouped2TableType.php
@@ -16,7 +16,7 @@ use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Omines\DataTablesBundle\Column\TextColumn;
 use Omines\DataTablesBundle\DataTable;
-use Omines\DataTablesBundle\DataTableTypeInterface;
+use Omines\DataTablesBundle\DataTableType;
 use Tests\Fixtures\AppBundle\DataTable\Adapter\CustomORMAdapter;
 use Tests\Fixtures\AppBundle\Entity\Company;
 
@@ -25,7 +25,7 @@ use Tests\Fixtures\AppBundle\Entity\Company;
  *
  * @author Niels Keurentjes <niels.keurentjes@omines.com>
  */
-class Grouped2TableType implements DataTableTypeInterface
+class Grouped2TableType extends DataTableType
 {
     public function configure(DataTable $dataTable, array $options): void
     {

--- a/tests/Fixtures/AppBundle/DataTable/Type/GroupedTableType.php
+++ b/tests/Fixtures/AppBundle/DataTable/Type/GroupedTableType.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\QueryBuilder;
 use Omines\DataTablesBundle\Adapter\Doctrine\ORMAdapter;
 use Omines\DataTablesBundle\Column\TextColumn;
 use Omines\DataTablesBundle\DataTable;
-use Omines\DataTablesBundle\DataTableTypeInterface;
+use Omines\DataTablesBundle\DataTableType;
 use Tests\Fixtures\AppBundle\Entity\Company;
 
 /**
@@ -25,7 +25,7 @@ use Tests\Fixtures\AppBundle\Entity\Company;
  *
  * @author Niels Keurentjes <niels.keurentjes@omines.com>
  */
-class GroupedTableType implements DataTableTypeInterface
+class GroupedTableType extends DataTableType
 {
     public function configure(DataTable $dataTable, array $options): void
     {

--- a/tests/Fixtures/AppBundle/DataTable/Type/PersonTableConfigureType.php
+++ b/tests/Fixtures/AppBundle/DataTable/Type/PersonTableConfigureType.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * Symfony DataTables Bundle
+ * (c) Omines Internetbureau B.V. - https://omines.nl/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\AppBundle\DataTable\Type;
+
+use Omines\DataTablesBundle\Adapter\ArrayAdapter;
+use Omines\DataTablesBundle\Column\TextColumn;
+use Omines\DataTablesBundle\DataTable;
+use Omines\DataTablesBundle\DataTableType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class PersonTableConfigureType extends DataTableType
+{
+    public function configure(DataTable $dataTable, array $options): void
+    {
+        $fruit_column = $options['fruit'];
+        $dataTable
+            ->add('firstName', TextColumn::class)
+            ->add($fruit_column, TextColumn::class)
+            ->createAdapter(ArrayAdapter::class, [
+                ['firstName' => 'Fred', $fruit_column => 'yellow'],
+                ['firstName' => 'George', $fruit_column => 'green'],
+                ['firstName' => 'Ringo', $fruit_column => 'white'],
+                ['firstName' => 'Bill', $fruit_column => 'rotten'],
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'fruit' => 'banana',
+        ]);
+    }
+
+    public function configureTableOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'fixedHeader' => true,
+        ]);
+    }
+}

--- a/tests/Fixtures/AppBundle/DataTable/Type/RegularPersonTableType.php
+++ b/tests/Fixtures/AppBundle/DataTable/Type/RegularPersonTableType.php
@@ -16,14 +16,14 @@ use Omines\DataTablesBundle\Adapter\ArrayAdapter;
 use Omines\DataTablesBundle\Column\DateTimeColumn;
 use Omines\DataTablesBundle\Column\TextColumn;
 use Omines\DataTablesBundle\DataTable;
-use Omines\DataTablesBundle\DataTableTypeInterface;
+use Omines\DataTablesBundle\DataTableType;
 
 /**
  * RegularPersonTableType.
  *
  * @author Niels Keurentjes <niels.keurentjes@omines.com>
  */
-class RegularPersonTableType implements DataTableTypeInterface
+class RegularPersonTableType extends DataTableType
 {
     public function configure(DataTable $dataTable, array $optionss): void
     {

--- a/tests/Fixtures/AppBundle/DataTable/Type/ServicePersonTableType.php
+++ b/tests/Fixtures/AppBundle/DataTable/Type/ServicePersonTableType.php
@@ -16,7 +16,7 @@ use Omines\DataTablesBundle\Adapter\Doctrine\ORM\SearchCriteriaProvider;
 use Omines\DataTablesBundle\Adapter\Doctrine\ORMAdapter;
 use Omines\DataTablesBundle\Column\TextColumn;
 use Omines\DataTablesBundle\DataTable;
-use Omines\DataTablesBundle\DataTableTypeInterface;
+use Omines\DataTablesBundle\DataTableType;
 use Symfony\Component\Routing\RouterInterface;
 use Tests\Fixtures\AppBundle\Entity\Employee;
 use Tests\Fixtures\AppBundle\Entity\Person;
@@ -26,7 +26,7 @@ use Tests\Fixtures\AppBundle\Entity\Person;
  *
  * @author Niels Keurentjes <niels.keurentjes@omines.com>
  */
-class ServicePersonTableType implements DataTableTypeInterface
+class ServicePersonTableType extends DataTableType
 {
     /** @var RouterInterface */
     private $router;

--- a/tests/Unit/DataTableTypeTest.php
+++ b/tests/Unit/DataTableTypeTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * Symfony DataTables Bundle
+ * (c) Omines Internetbureau B.V. - https://omines.nl/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Omines\DataTablesBundle\DataTable;
+use Omines\DataTablesBundle\DataTableFactory;
+use Omines\DataTablesBundle\DependencyInjection\Instantiator;
+use Omines\DataTablesBundle\Exporter\DataTableExporterManager;
+use Omines\DataTablesBundle\Twig\TwigRenderer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Tests\Fixtures\AppBundle\DataTable\Type\PersonTableConfigureType;
+
+class DataTableTypeTest extends TestCase
+{
+    public function testTypeFromFactory(): void
+    {
+        $factory = new DataTableFactory([], $this->createMock(TwigRenderer::class), new Instantiator(), $this->createMock(EventDispatcher::class), $this->createMock(DataTableExporterManager::class));
+
+        $table = $factory->createFromType(PersonTableConfigureType::class);
+
+        $this->assertInstanceOf(DataTable::class, $table);
+        $this->assertSame('banana', $table->getColumnByName('banana')->getName());
+        $this->assertSame(true, $table->getOption('fixedHeader'));
+    }
+
+    public function testTypeFromFactoryWithTypeOptions(): void
+    {
+        $factory = new DataTableFactory([], $this->createMock(TwigRenderer::class), new Instantiator(), $this->createMock(EventDispatcher::class), $this->createMock(DataTableExporterManager::class));
+
+        $table = $factory->createFromType(PersonTableConfigureType::class, ['fruit' => 'orange']);
+
+        $this->assertInstanceOf(DataTable::class, $table);
+        $this->assertSame('orange', $table->getColumnByName('orange')->getName());
+        $this->assertSame(true, $table->getOption('fixedHeader'));
+    }
+
+    public function testTypeFromFactoryWithTableOptions(): void
+    {
+        $factory = new DataTableFactory([], $this->createMock(TwigRenderer::class), new Instantiator(), $this->createMock(EventDispatcher::class), $this->createMock(DataTableExporterManager::class));
+
+        $table = $factory->createFromType(PersonTableConfigureType::class, [], ['pageLength' => 100]);
+
+        $this->assertInstanceOf(DataTable::class, $table);
+        $this->assertSame(100, $table->getOption('pageLength'));
+        $this->assertSame(true, $table->getOption('fixedHeader'));
+    }
+}


### PR DESCRIPTION
Like symfony "Form" Component this will now provide

1. A default abstract table class to extend
2. An interface that is options aware for bundling overall table options into types and creating options for types

This IS a BC break, but easy to fix
use DataTableType instead of DataTableTypeInterface

extend DataTableType instead of implement DataTableTypeInferface

Otherwise older functionality is identical

You can still implement DataTableType but you must provide the two configure methods as well

Added info in the changelog and updated tests to use the abstract class, added unit tests for configuration for all the stuff