### PR TITLE
Fix javascript API usage for state restoration

### DIFF
--- a/src/Resources/public/js/datatables.js
+++ b/src/Resources/public/js/datatables.js
@@ -7,6 +7,7 @@
  *
  * @author Niels Keurentjes <niels.keurentjes@omines.com>
  */
+import jQuery from 'jquery';
 
 (function($) {
     /**
@@ -78,12 +79,7 @@
                             if (Object.keys(state).length) {
                                 var api = new $.fn.dataTable.Api( settings );
                                 var merged = Object.assign({}, api.state(), state)
-                                api
-                                    .order(Array.isArray(merged.order) && merged.order.length > 0 ? merged.order : api.state().order)
-                                    .search(merged.search.search)
-                                    .page.len(merged.length)
-                                    .page(merged.start / merged.length)
-                                    .draw(false);
+                                api.state(merged).draw(false);
                             }
                         } else {
                             request._dt = config.name;


### PR DESCRIPTION
Added import statement for jquery for use with modules
Replaced bad api usage for state restoration to built in api call

The core datatables api state restoration call takes all state settings into accounting including column hide/show, column filtering and searching, and column reorder, all of which were missing in the current iteration of state restoration

Use the API Luke