### PR TITLE
Additional options for columns in definitions

### DIFF
--- a/src/Column/AbstractColumn.php
+++ b/src/Column/AbstractColumn.php
@@ -125,6 +125,9 @@ abstract class AbstractColumn
             ->setAllowedTypes('rightExpr', ['null', 'string', 'callable'])
         ;
 
+	$resolver->setDefined(['options']);
+        $resolver->setAllowedTypes('options', ['array', 'null']);
+
         return $this;
     }
 
@@ -222,6 +225,11 @@ abstract class AbstractColumn
     public function getClassName(): ?string
     {
         return $this->options['className'] ?? null;
+    }
+
+    public function getColumnOptions(): ?array
+    {
+        return $this->options['options'] ?? null;
     }
 
     public function getDataTable(): DataTable

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -296,13 +296,20 @@ class DataTable
         return array_merge($this->getOptions(), [
             'columns' => array_map(
                 function (AbstractColumn $column) {
-                    return [
+                    $settings = [
                         'data' => $column->getName(),
                         'orderable' => $column->isOrderable(),
                         'searchable' => $column->isSearchable(),
                         'visible' => $column->isVisible(),
                         'className' => $column->getClassName(),
                     ];
+
+                    if($options = $column->getColumnOptions())
+                    {
+                        $settings = $settings += $options;
+                    }
+
+                    return $settings;
                 }, $this->getColumns()
             ),
         ]);


### PR DESCRIPTION
Add options for abstract columns to pass additional settings to javascript for column definitions

This is a pretty "dumb" definition with zero checking

but it also allows for a lot of flexibility with plugin usage